### PR TITLE
Add RTL language support and save preference

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { Toaster } from 'sonner';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
+import { LanguageProvider } from '@/lib/lang';
 
 import './globals.css';
 import { SessionProvider } from 'next-auth/react';
@@ -48,6 +49,22 @@ const THEME_COLOR_SCRIPT = `\
   updateThemeColor();
 })();`;
 
+const LANGUAGE_SCRIPT = `\
+(function() {
+  try {
+    var html = document.documentElement;
+    var stored = localStorage.getItem('app:language');
+    var lang = stored === 'ar' ? 'ar' : 'en';
+    // If nothing stored, try browser setting
+    if (!stored) {
+      var nav = (navigator.language || 'en').toLowerCase();
+      if (nav.indexOf('ar') === 0) lang = 'ar';
+    }
+    html.setAttribute('lang', lang);
+    html.setAttribute('dir', lang === 'ar' ? 'rtl' : 'ltr');
+  } catch (e) {}
+})();`;
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -69,6 +86,11 @@ export default async function RootLayout({
             __html: THEME_COLOR_SCRIPT,
           }}
         />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: LANGUAGE_SCRIPT,
+          }}
+        />
       </head>
       <body className="antialiased">
         <ThemeProvider
@@ -77,8 +99,10 @@ export default async function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <Toaster position="top-center" />
-          <SessionProvider>{children}</SessionProvider>
+          <LanguageProvider>
+            <Toaster position="top-center" />
+            <SessionProvider>{children}</SessionProvider>
+          </LanguageProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -11,6 +11,7 @@ import { useSidebar } from './ui/sidebar';
 import { memo } from 'react';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
+import { useLanguage } from '@/lib/lang';
 
 function PureChatHeader({
   chatId,
@@ -27,6 +28,7 @@ function PureChatHeader({
   const { open } = useSidebar();
 
   const { width: windowWidth } = useWindowSize();
+  const { language, toggleLanguage } = useLanguage();
 
   return (
     <header className="sticky top-0 flex items-center gap-2 bg-background px-2 py-1.5 md:px-2">
@@ -66,6 +68,14 @@ function PureChatHeader({
           <VercelIcon size={16} />
           Deploy with Vercel
         </Link>
+      </Button>
+
+      <Button
+        variant="outline"
+        className="order-4 ml-2 h-8 px-2"
+        onClick={toggleLanguage}
+      >
+        {language === 'ar' ? 'English' : 'العربية'}
       </Button>
     </header>
   );

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -22,11 +22,13 @@ import { useRouter } from 'next/navigation';
 import { toast } from './toast';
 import { LoaderIcon } from './icons';
 import { guestRegex } from '@/lib/constants';
+import { useLanguage } from '@/lib/lang';
 
 export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
   const { data, status } = useSession();
   const { setTheme, resolvedTheme } = useTheme();
+  const { language, toggleLanguage } = useLanguage();
 
   const isGuest = guestRegex.test(data?.user?.email ?? '');
 
@@ -79,6 +81,17 @@ export function SidebarUserNav({ user }: { user: User }) {
               }
             >
               {`Toggle ${resolvedTheme === 'light' ? 'dark' : 'light'} mode`}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              data-testid="user-nav-item-language"
+              className="cursor-pointer"
+              onSelect={(e: Event) => {
+                // prevent closing to improve UX
+                e?.preventDefault?.();
+                toggleLanguage();
+              }}
+            >
+              {language === 'ar' ? 'Switch to English' : 'التبديل إلى العربية'}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">

--- a/lib/lang.tsx
+++ b/lib/lang.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+type SupportedLanguage = "en" | "ar";
+
+type LanguageContextValue = {
+  language: SupportedLanguage;
+  direction: "ltr" | "rtl";
+  setLanguage: (lang: SupportedLanguage) => void;
+  toggleLanguage: () => void;
+};
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "app:language";
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguageState] = useState<SupportedLanguage>(() => {
+    if (typeof window === "undefined") return "en";
+    const stored = window.localStorage.getItem(STORAGE_KEY) as SupportedLanguage | null;
+    if (stored === "en" || stored === "ar") return stored;
+    // Fallback to browser language
+    const nav = navigator.language?.toLowerCase() || "en";
+    return nav.startsWith("ar") ? "ar" : "en";
+  });
+
+  const direction = language === "ar" ? "rtl" : "ltr";
+
+  const applyToHtml = useCallback((lang: SupportedLanguage) => {
+    const html = document.documentElement;
+    html.setAttribute("lang", lang);
+    html.setAttribute("dir", lang === "ar" ? "rtl" : "ltr");
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    applyToHtml(language);
+  }, [language, applyToHtml]);
+
+  const setLanguage = useCallback((lang: SupportedLanguage) => {
+    setLanguageState(lang);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, lang);
+    }
+  }, []);
+
+  const toggleLanguage = useCallback(() => {
+    setLanguageState((prevLanguage: SupportedLanguage) => {
+      const next = prevLanguage === "en" ? "ar" : "en";
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(STORAGE_KEY, next);
+      }
+      return next as SupportedLanguage;
+    });
+  }, []);
+
+  const value = useMemo<LanguageContextValue>(() => ({
+    language,
+    direction,
+    setLanguage,
+    toggleLanguage,
+  }), [language, direction, setLanguage, toggleLanguage]);
+
+  return (
+    <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error("useLanguage must be used within LanguageProvider");
+  return ctx;
+}
+


### PR DESCRIPTION
Add RTL support and language switching with localStorage persistence to allow users to switch between English and Arabic.

A pre-hydration script is used to set the `lang` and `dir` attributes early, preventing a flicker when the page loads with the stored language preference.

---
<a href="https://cursor.com/background-agent?bcId=bc-01974d07-712b-4b0d-95db-b0a3c17b1152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01974d07-712b-4b0d-95db-b0a3c17b1152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

